### PR TITLE
Pass store directly instead of using Provider

### DIFF
--- a/src/containers/Subdivide.js
+++ b/src/containers/Subdivide.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { createStore } from 'redux';
-import { Provider } from 'react-redux';
 import reducer from '../reducers';
 import LayoutContainer from './LayoutContainer';
 
@@ -9,7 +8,7 @@ function configureStore(initialState) {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers/index');
+      const nextRootReducer = require('../reducers');
       store.replaceReducer(nextRootReducer);
     });
   }
@@ -17,17 +16,16 @@ function configureStore(initialState) {
   return store;
 }
 
-const store = configureStore();
-//window.store = store;
-
 export default class Subdivide extends Component {
+  constructor(props) {
+    super(props);
+    this.store = configureStore();
+  }
 
   render() {
     const {DefaultComponent} = this.props;
     return (
-      <Provider store={store}>
-        <LayoutContainer DefaultComponent={DefaultComponent} />
-      </Provider>
+      <LayoutContainer DefaultComponent={DefaultComponent} store={this.store} />
     );
   }
 }


### PR DESCRIPTION
It feels like `<Provider>` is unnecessary because we always own the only connected component.
In addition, this helps against “connected component inside Subdivide gets the wrong store” kind of issues.
