### PR TITLE
Fix typo and pass subdividePane to the component

### DIFF
--- a/src/components/Pane.js
+++ b/src/components/Pane.js
@@ -50,7 +50,10 @@ export default class Pane extends Component {
 
     return (
       <div style={styles.pane} onMouseMove={this.onMouseMove} onMouseUp={this.onMouseUp}>
-        <DefaultComponent {...pane.props} subdivdeActions={actions} subdivide={subdivide} />
+        <DefaultComponent
+          subdividePane={pane}
+          subdivideActions={actions}
+          subdivide={subdivide} />
         <CornerOverlay pane={pane} subdivide={subdivide} />
         <Triangle
           corner={SW}


### PR DESCRIPTION
This commit
- Fixes a typo: `subdivdeActions` -> `subdivideActions`
- Adds `subdividePane` prop to the component
- Removes `{...pane.props}` because it is redundant with the prop above

I need to have access to the pane so I can store the state of monitors inside them separately in Redux DevTools. Please let me know if this is the wrong way to approach this.

This is a breaking change, so after merging this it's a good time to bump to 0.2.0.
